### PR TITLE
install httpx

### DIFF
--- a/.github/workflows/first-action.yml
+++ b/.github/workflows/first-action.yml
@@ -10,13 +10,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install fastapi uvicorn
+        run: uv sync --locked
       - name: Run unit tests
-        run: python -m unittest discover -s tests
+        run: uv run python -m unittest discover -s tests
 
   deploy:
     needs: test
@@ -27,15 +27,16 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - name: Install dependencies
+        run: uv sync --locked
+      - name: Smoke test FastAPI deployment
         run: |
-          python -m pip install --upgrade pip
-          pip install fastapi uvicorn
-      - name: Deploy FastAPI locally for smoke test
-        run: |
-          uvicorn main:app --host 0.0.0.0 --port 8000 &
+          uv run uvicorn main:app --host 0.0.0.0 --port 8000 &
           SERVER_PID=$!
+          trap "kill $SERVER_PID" EXIT
           echo "Started FastAPI (PID: $SERVER_PID)"
           for i in {1..10}; do
             if curl -sSf http://127.0.0.1:8000/health > /dev/null; then
@@ -48,5 +49,4 @@ jobs:
           curl -sSf -X POST http://127.0.0.1:8000/average \
             -H 'Content-Type: application/json' \
             -d '{"values":[1,2,3,4]}'
-          kill $SERVER_PID
-          echo "FastAPI process stopped"
+          echo "FastAPI smoke test succeeded"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,6 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.121.2",
+    "httpx>=0.28.1",
     "uvicorn>=0.25.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -35,6 +35,15 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2025.11.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/8c/58f469717fa48465e4a50c014a0400602d3c437d7c0c468e17ada824da3a/certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316", size = 160538, upload_time = "2025-11-12T02:54:51.517Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b", size = 159438, upload_time = "2025-11-12T02:54:49.735Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -76,12 +85,14 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "uvicorn" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.121.2" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "uvicorn", specifier = ">=0.25.0" },
 ]
 
@@ -92,6 +103,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload_time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload_time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload_time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload_time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload_time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload_time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request updates the CI workflow and project dependencies to use Python 3.12 and the `uv` package manager, streamlining dependency management and test execution. It also introduces `httpx` as a new dependency and improves the FastAPI smoke test process.

**CI/CD workflow improvements:**

* Upgraded the workflow to use Python 3.12 instead of 3.11 and added a step to install the `uv` package manager (`astral-sh/setup-uv@v3`). [[1]](diffhunk://#diff-06d8b5853f33a02b1d2e2ef9a0ee7516d87869de74ada1043ffcf0ac0f1f21e2L13-R19) [[2]](diffhunk://#diff-06d8b5853f33a02b1d2e2ef9a0ee7516d87869de74ada1043ffcf0ac0f1f21e2L30-R39)
* Replaced manual pip commands with `uv sync --locked` for dependency installation, and updated test and run commands to use `uv run` for consistency. [[1]](diffhunk://#diff-06d8b5853f33a02b1d2e2ef9a0ee7516d87869de74ada1043ffcf0ac0f1f21e2L13-R19) [[2]](diffhunk://#diff-06d8b5853f33a02b1d2e2ef9a0ee7516d87869de74ada1043ffcf0ac0f1f21e2L30-R39)

**FastAPI smoke test enhancements:**

* Combined FastAPI deployment and smoke test steps, using `uv run` to launch the server and a `trap` to ensure proper cleanup of the server process after tests.
* Improved test output by removing explicit process kill and providing a clear success message upon completion.

**Dependency updates:**

* Added `httpx>=0.28.1` to the project dependencies in `pyproject.toml`.